### PR TITLE
Błąd w negacji (VNOT)

### DIFF
--- a/007-Czesc_II-Rozdzial_3-Podstawy_architektury_komputerowe/vm_instr.py
+++ b/007-Czesc_II-Rozdzial_3-Podstawy_architektury_komputerowe/vm_instr.py
@@ -92,7 +92,7 @@ def VXOR(vm, args):
 
 
 def VNOT(vm, args):
-  vm.reg(args[0]).v = vm.reg(args[0]).v ^ 0xffffffff
+  vm.reg(args[0]).v = (vm.reg(args[0]).v ^ 0xffffffff) + 0x1
 
 
 def VSHL(vm, args):


### PR DESCRIPTION
Na koniec powinno być dodane 0x1 by faktycznie zaistniała negacja.